### PR TITLE
Fixed display of dispatches.

### DIFF
--- a/views/dispatch/dispatching.hbs
+++ b/views/dispatch/dispatching.hbs
@@ -207,7 +207,7 @@
 
 
 <!-- Request Card Forms, Input Fields, and Processing Code  ------------------->
-<!--  <script src="/javascripts/dispatch/request-form.js"></script> -->
+<script src="/javascripts/dispatch/request-form.js"></script>
 <script src="/javascripts/dispatch/request-create.js"></script>
 <script src="/javascripts/dispatch/request-edit.js"></script>
 <script src="/javascripts/dispatch/request-delete.js"></script>


### PR DESCRIPTION
A required js file was commented out in the template, so the javascript was dying before it could load requests.